### PR TITLE
Print URL if getDesktop.browse doesn't work.

### DIFF
--- a/src/main/java/com/google/sites/liberation/util/GuiMain.java
+++ b/src/main/java/com/google/sites/liberation/util/GuiMain.java
@@ -227,10 +227,11 @@ public class GuiMain {
     try {
       // Point or redirect your user to the authorizationUrl.
       java.awt.Desktop.getDesktop().browse(new URI(authorizationUrl));
-    } catch (URISyntaxException e) {
-      e.printStackTrace();
-    } catch (IOException e) {
-      e.printStackTrace();
+    } catch (Exception e) {
+      LOGGER.warning("Unable to open browser: " + e.toString());
+      LOGGER.info("Go to: " + authorizationUrl);
+      JOptionPane.showMessageDialog(optionsFrame, "Cannot open browser. Check the console for the necessary URL.",
+                                    "Error", JOptionPane.ERROR_MESSAGE);
     }
     // End of Step 1 <--
   }


### PR DESCRIPTION
If getDesktop().browse is not supported on the current platform (common for Linux systems), then currently the application will not allow the user to get the URL for the authorization token at all. This pull request will print the URL in the console if opening the browser does not work as a workaround for the above issue.